### PR TITLE
Update config defaults

### DIFF
--- a/pam_encfs.conf
+++ b/pam_encfs.conf
@@ -13,7 +13,7 @@ encfs_default --idle=1
 
 #Same for fuse, note that allow_root (or allow_other, or --public in encfs) is needed to run gdm/X.
 #you can find fuse options with encfs -H
-fuse_default allow_root,nonempty
+fuse_default nonempty
 
 #For a mount line, - = generic, we try to fill in what we need.
 #A Mount line is constructed like this:
@@ -31,8 +31,9 @@ fuse_default allow_root,nonempty
 
 #In this example, with example_user uncommented, the "-" line will never be parsed if you login as example_user.
 #In the lines with the USERNAME "*", all paths are relative to $HOME
-#USERNAME    	SOURCE 					TARGET PATH      	ENCFS Options		FUSE Options
-#example_user	/mnt/enc/example_user	/home/example_user	-v,--idle=1			allow_root
-#*				.private				private				-v					allow_other
--				/mnt/enc				- 					-v					allow_other
+#USERNAME    	SOURCE 			TARGET PATH      	ENCFS Options		FUSE Options
+#example_user	/mnt/enc/example_user	/home/example_user	-v,--idle=1		allow_root
+#*		.private		private			-v			allow_other
+#-		/mnt/enc		- 			-v			allow_other
+-		/home/.enc		- 			-v			allow_root
 


### PR DESCRIPTION
Update the config default following the changes done for Debian:
https://salsa.debian.org/debian/libpam-encfs/-/blob/master/debian/pam_encfs.conf

* Better indentation
* Avoid setting both `allow_other` and `allow_root` at the same time

```
# - Debian Note:
# allow_other and allow_root are mutually incompatible and cannot be set 
# simultaneously. If we set any of them here (as done before) all users 
# inherit it and the other option cannot be set for any user. We better 
# do not set it here, but in specific definitions at the end of this file.
```